### PR TITLE
DB 자료구조 Json으로 변경 및 최적화

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Barengak Alliance Bans System
-Addon Version : v2.0
+Addon Version : v2.1
 ## Apply
 Install script to the `"/garrysmod/addons/"` folder.
 ## License

--- a/addons/[_BABS_] Bareungak Aliance Bans System/lua/autorun/server/babs_sv_init.lua
+++ b/addons/[_BABS_] Bareungak Aliance Bans System/lua/autorun/server/babs_sv_init.lua
@@ -10,15 +10,15 @@ Config.KickAllSub = true --"true"로 놓으시면 가족공유 계정이 모두 
 Config.Banlist = {}
 Config.BanSlist = {}
 Config.LVersion = "" --서버로부터 불러온 최신버전
-Config.URL = "https://raw.githubusercontent.com/BareungakServer/Barengak-Alliance-Bans/master/db_bans_meta.html" --데이터베이스 링크
---구버젼과 충돌 방지를 위해 URL에는 _meta 수식어 붙임
+Config.URL = "https://raw.githubusercontent.com/BareungakServer/Barengak-Alliance-Bans/master/db_bans.json" --데이터베이스 링크
+--서버 자료구조를 더 강력한 json으로 변경
 
 if SERVER then
     util.AddNetworkString("BABSMenu")
 
     function BABScheck()
         http.Fetch(Config.URL, function(body)
-            Config.Banlist = string.Explode("|", string.Replace(body," ",""))
+            Config.Banlist = util.JSONToTable(body)
             --for _, item in pairs(Config.Banlist) do --이러면 의미가 없음
             --  Config.Banlist[item] = true
             --end

--- a/addons/[_BABS_] Bareungak Aliance Bans System/lua/autorun/server/babs_sv_init.lua
+++ b/addons/[_BABS_] Bareungak Aliance Bans System/lua/autorun/server/babs_sv_init.lua
@@ -1,37 +1,39 @@
 BABSConfigs = {}
 
 local Config = BABSConfigs
-Config.Version = 2.0 --연합밴  현재 버전
+Config.Version = 2.1 --연합밴  현재 버전
 Config.Command = "!연합밴" --연합밴  메뉴 명령어
-Config.LVersion = "" --서버로부터 불러온 최신버전
-Config.URL = "https://raw.githubusercontent.com/BareungakServer/Barengak-Alliance-Bans/master/db_bans.html" --데이터베이스 링크 
 Config.APIKey = "" --스팀 API 키를 큰따옴표 사이에 입력해주세요.
 Config.Reason = "[BABS] 연합밴 사유: http://steamcommunity.com/groups/barnaliedbans"
-Config.KickAllSub = true --"true"로 놓으시면 가족공유 계정이 모두 차단됩니다 (기본 false)
+Config.KickAllSub = false --true로 놓으시면 가족공유 계정이 모두 차단됩니다 (기본 false)
+--------------[이 아래는 만지지 마세요]--------------
 Config.Banlist = {}
 Config.BanSlist = {}
+Config.LVersion = "" --서버로부터 불러온 최신버전
+Config.URL = "https://raw.githubusercontent.com/BareungakServer/Barengak-Alliance-Bans/master/db_bans_meta.html" --데이터베이스 링크
+--구버젼과 충돌 방지를 위해 URL에는 _meta 수식어 붙임
 
 if SERVER then
     util.AddNetworkString("BABSMenu")
 
     function BABScheck()
         http.Fetch(Config.URL, function(body)
-            Config.Banlist = string.Explode("|", string.Replace(body,"",""))
-            for _, item in pairs(Config.Banlist) do
-              Config.BanSlist[string.Trim(item)] = true
-            end
+            Config.Banlist = string.Explode("|", string.Replace(body," ",""))
+            --for _, item in pairs(Config.Banlist) do --이러면 의미가 없음
+            --  Config.Banlist[item] = true
+            --end
 
-            Config.LVersion = tonumber(Config.Banlist[1])
+            Config.LVersion = tonumber(Config.Banlist["Ver"])
 
             if (Config.LVersion > Config.Version) then
-                MsgC(Color(255, 0, 0), "[BABS] 새로운 업데이트가 있습니다!\n")
+                MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)" 새로운 업데이트가 있습니다!\n")
                 PrintMessage(HUD_PRINTTALK, "[BABS] 새로운 업데이트가 있습니다!\n")
             end
 
-            MsgC(Color(255, 0, 0), "[BABS] 데이터베이스 업데이트 완료!\n")
+            MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)" 데이터베이스 업데이트 완료!\n")
             PrintMessage(HUD_PRINTTALK, "[BABS] 데이터베이스 업데이트 완료!\n")
         end, function(error)
-            MsgC(Color(255, 0, 0), "[BABS] 데이터베이스를 업데이트 하는동안 오류가 발생하였습니다. " .. error .. "\n")
+            MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)" 데이터베이스를 업데이트 하는동안 오류가 발생하였습니다. " .. error .. "\n")
         end)
     end
 
@@ -40,29 +42,33 @@ if SERVER then
             local body = util.JSONToTable(body)
 
             if (not body or not body.response or not body.response.lender_steamid) then
-                MsgC(Color(255, 0, 0), "[BABS] API 값을 받지 못했습니다, SteamAPI 키가 제대로 적혀있는지 확인해주세요.\n")
+                MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)" API 값을 받지 못했습니다, SteamAPI 키가 제대로 적혀있는지 확인해주세요.\n")
 
-                return ""
+                return
             end
 
             local lender = body.response.lender_steamid
 
             if (Config.KickAllSub and lender ~= 0) then
-                BABSkickuser(v, 1)
+                v:Kick("[BABS] 이 서버에서는 가족공유 계정이 금지되어 있습니다.") -- 자체 함수로 킥하면 연합밴으로 혼동할 가능성 있음
+                local txt = "[BABS] " .. v:Nick() .. "(고유번호 " .. v:SteamID() .. ") 는(은) 가족공유 계정으로 인해 추방되었습니다! " .. "[" .. os.date("%Y:%m:%d / %H:%M:%S") .. "]\n"
+                MsgC(Color(255, 150, 0), txt)
+                PrintMessage(HUD_PRINTTALK, txt)
+                file.Append("babs/log.txt", txt)
             end
 
-                if (Config.BanSlist[util.SteamIDFrom64(lender)] == true) then
+                if (Config.Banlist[util.SteamIDFrom64(lender)]) then
                     BABSkickuser(v, 1)
                 end
 
 
         end, function(error)
-            MsgC(Color(255, 0, 0), "[BABS] SteamAPI 응답이 올바르지 않습니다. Steam 서버가 닫혀 있을 수도 있습니다. " .. error .. "\n")
+            MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)" SteamAPI 응답이 올바르지 않습니다. Steam 서버가 닫혀 있을 수도 있습니다. " .. error .. "\n")
         end)
     end
 
     function BABSaliget(v)
-        if (Config.BanSlist[v:SteamID()] == true) then
+        if (Config.Banlist[v:SteamID()]) then
            BABSkickuser(v, 0)
         end
     end
@@ -70,12 +76,11 @@ if SERVER then
     function BABSkickuser(v,id)
         local reason = Config.Reason
         if(id == 0) then
-        local txt = "[BABS]" .. v:Nick() .. " 스팀 아이디 " .. v:SteamID() .. " 는(은) 바른각 연합밴 시스템에 의하여 공식 추방되었습니다! " .. "[" .. os.date("%Y:%m:%d / %H:%M:%S") .. "]\n"
-
-    else
-        reason = Config.Reason .. " (부계정 감지)"
-         local txt = "[BABS]" .. v:Nick() .. " 스팀 아이디 " .. v:SteamID() .. " 는(은) 바른각 연합밴 시스템에 의하여 공식 추방되었습니다! (부계정 감지) " .. "[" .. os.date("%Y:%m:%d / %H:%M:%S") .. "]\n"
-    end
+            local txt = "[BABS] " .. v:Nick() .. " (고유번호 " .. v:SteamID() .. ") 는(은) 바른각 연합밴 시스템에 의하여 공식 추방되었습니다! " .. "[" .. os.date("%Y:%m:%d / %H:%M:%S") .. "]\n"
+        else
+            reason = reason .. " (부계정 감지)"
+            local txt = "[BABS] " .. v:Nick() .. " (고유번호 " .. v:SteamID() .. ") 는(은) 바른각 연합밴 시스템에 의하여 공식 추방되었습니다! (부계정 감지) " .. "[" .. os.date("%Y:%m:%d / %H:%M:%S") .. "]\n"
+        end
         v:Kick(reason)
         MsgC(Color(255, 0, 0), txt)
         PrintMessage(HUD_PRINTTALK, txt)
@@ -85,8 +90,8 @@ if SERVER then
 
     hook.Add("Initialize", "InitializeBABS", function()
         BABScheck()
-        timer.Create("UpdateBABS", 600, 0, BABScheck)
-        MsgC(Color(255, 0, 0), "[BABS] 시스템이 로딩되었습니다! 현재 버전 : v" .. Config.Version .. "\n")
+        timer.Create("UpdateBABS", 1800, 0, BABScheck)
+        MsgC(Color(0, 210, 255), "[BABS]",Color(255,255,255)" 시스템이 로딩되었습니다! 현재 버전 : v" .. Config.Version .. "\n")
     end)
 
     hook.Add("PlayerAuthed", "BABSCheckUsers", function(v)
@@ -97,22 +102,25 @@ if SERVER then
 
     hook.Add("PlayerSay", "BABSCallMenu", function(v, cmd)
         if (string.Trim(string.lower(cmd)) == Config.Command and v:IsSuperAdmin()) then
-                net.Start("BABSMenu")
-                net.Send(v)
+            net.Start("BABSMenu")
+            net.Send(v)
+            return ""
         end
     end)
 
-        concommand.Add("babs_update", function(v)
-        if (v:IsSuperAdmin() and v:IsValid()) then
+    concommand.Add("babs_update", function(v)
+        if (not v:IsValid() or v:IsSuperAdmin()) then --서버 콘솔인경우 IsValid == false
             BABScheck()
         end
     end)
 
     concommand.Add("babs_getlist", function(v)
         if v:IsValid() then
-                v:PrintMessage(HUD_PRINTTALK, "버전, 스팀아이디" .. table.ToString(Config.Banlist))
+            v:PrintMessage(HUD_PRINTTALK, "[BABS] 콘솔을 보세요.") --밴리스트가 방대해지면 콘솔 출력이 더 나음
+            v:PrintMessage(HUD_PRINTCONSOLE,table.ToString(Config.Banlist,"Ban List",true))
         else
-        MsgN("Version, SteamID" .. table.ToString(Config.Banlist))
+        MsgN("Version, SteamID:")
+        PrintTable(Config.Banlist)
     end
 
 
@@ -120,9 +128,9 @@ if SERVER then
 
     concommand.Add("babs_getversion", function(v)
         if v:IsValid() then
-        v:PrintMessage(HUD_PRINTTALK, "최신 버전 : " .. Config.LVersion .. "  현재 버전 : " .. Config.Version)
+            v:PrintMessage(HUD_PRINTTALK, "[BABS] 최신 버전 : " .. Config.LVersion .. "  현재 버전 : " .. Config.Version)
         else
-        MsgN("Last version : " .. Config.LVersion .. "  Current version : " .. Config.Version)
-    end
+            MsgN("[BABS] Last version : " .. Config.LVersion .. "  Current version : " .. Config.Version)
+        end
     end)
 end

--- a/addons/[_BABS_] Bareungak Aliance Bans System/lua/autorun/server/babs_sv_init.lua
+++ b/addons/[_BABS_] Bareungak Aliance Bans System/lua/autorun/server/babs_sv_init.lua
@@ -5,7 +5,7 @@ Config.Version = 2.1 --연합밴  현재 버전
 Config.Command = "!연합밴" --연합밴  메뉴 명령어
 Config.APIKey = "" --스팀 API 키를 큰따옴표 사이에 입력해주세요.
 Config.Reason = "[BABS] 연합밴 사유: http://steamcommunity.com/groups/barnaliedbans"
-Config.KickAllSub = false --true로 놓으시면 가족공유 계정이 모두 차단됩니다 (기본 false)
+Config.KickAllSub = true --"true"로 놓으시면 가족공유 계정이 모두 차단됩니다 (기본 false)
 --------------[이 아래는 만지지 마세요]--------------
 Config.Banlist = {}
 Config.BanSlist = {}
@@ -26,14 +26,14 @@ if SERVER then
             Config.LVersion = tonumber(Config.Banlist["Ver"])
 
             if (Config.LVersion > Config.Version) then
-                MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)" 새로운 업데이트가 있습니다!\n")
+                MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)," 새로운 업데이트가 있습니다!\n")
                 PrintMessage(HUD_PRINTTALK, "[BABS] 새로운 업데이트가 있습니다!\n")
             end
 
-            MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)" 데이터베이스 업데이트 완료!\n")
+            MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)," 데이터베이스 업데이트 완료!\n")
             PrintMessage(HUD_PRINTTALK, "[BABS] 데이터베이스 업데이트 완료!\n")
         end, function(error)
-            MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)" 데이터베이스를 업데이트 하는동안 오류가 발생하였습니다. " .. error .. "\n")
+            MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)," 데이터베이스를 업데이트 하는동안 오류가 발생하였습니다. " .. error .. "\n")
         end)
     end
 
@@ -42,7 +42,7 @@ if SERVER then
             local body = util.JSONToTable(body)
 
             if (not body or not body.response or not body.response.lender_steamid) then
-                MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)" API 값을 받지 못했습니다, SteamAPI 키가 제대로 적혀있는지 확인해주세요.\n")
+                MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)," API 값을 받지 못했습니다, SteamAPI 키가 제대로 적혀있는지 확인해주세요.\n")
 
                 return
             end
@@ -63,7 +63,7 @@ if SERVER then
 
 
         end, function(error)
-            MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)" SteamAPI 응답이 올바르지 않습니다. Steam 서버가 닫혀 있을 수도 있습니다. " .. error .. "\n")
+            MsgC(Color(0, 212, 255), "[BABS]",Color(255,255,255)," SteamAPI 응답이 올바르지 않습니다. Steam 서버가 닫혀 있을 수도 있습니다. " .. error .. "\n")
         end)
     end
 
@@ -91,7 +91,7 @@ if SERVER then
     hook.Add("Initialize", "InitializeBABS", function()
         BABScheck()
         timer.Create("UpdateBABS", 1800, 0, BABScheck)
-        MsgC(Color(0, 210, 255), "[BABS]",Color(255,255,255)" 시스템이 로딩되었습니다! 현재 버전 : v" .. Config.Version .. "\n")
+        MsgC(Color(0, 210, 255), "[BABS]",Color(255,255,255)," 시스템이 로딩되었습니다! 현재 버전 : v" .. Config.Version .. "\n")
     end)
 
     hook.Add("PlayerAuthed", "BABSCheckUsers", function(v)

--- a/addons/[_BABS_] Bareungak Aliance Bans System/lua/autorun/server/babs_sv_init.lua
+++ b/addons/[_BABS_] Bareungak Aliance Bans System/lua/autorun/server/babs_sv_init.lua
@@ -5,13 +5,12 @@ Config.Version = 2.1 --연합밴  현재 버전
 Config.Command = "!연합밴" --연합밴  메뉴 명령어
 Config.APIKey = "" --스팀 API 키를 큰따옴표 사이에 입력해주세요.
 Config.Reason = "[BABS] 연합밴 사유: http://steamcommunity.com/groups/barnaliedbans"
-Config.KickAllSub = true --"true"로 놓으시면 가족공유 계정이 모두 차단됩니다 (기본 false)
+Config.KickAllSub = false --"true"로 놓으시면 가족공유 계정이 모두 차단됩니다 (기본 false)
 --------------[이 아래는 만지지 마세요]--------------
 Config.Banlist = {}
 Config.BanSlist = {}
 Config.LVersion = "" --서버로부터 불러온 최신버전
 Config.URL = "https://raw.githubusercontent.com/BareungakServer/Barengak-Alliance-Bans/master/db_bans.json" --데이터베이스 링크
---서버 자료구조를 더 강력한 json으로 변경
 
 if SERVER then
     util.AddNetworkString("BABSMenu")
@@ -19,9 +18,6 @@ if SERVER then
     function BABScheck()
         http.Fetch(Config.URL, function(body)
             Config.Banlist = util.JSONToTable(body)
-            --for _, item in pairs(Config.Banlist) do --이러면 의미가 없음
-            --  Config.Banlist[item] = true
-            --end
 
             Config.LVersion = tonumber(Config.Banlist["Ver"])
 

--- a/db_bans.json
+++ b/db_bans.json
@@ -1,0 +1,18 @@
+{
+	"Ver": 2.1,
+	"STEAM_0:1:49119531": true,
+	"STEAM_0:0:51824117": true,
+	"STEAM_0:1:423963145": true,
+	"STEAM_0:0:141615119": true,
+	"STEAM_0:1:423627134": true,
+	"STEAM_0:1:423724530": true,
+	"STEAM_0:1:425295057": true,
+	"STEAM_0:1:424507398": true,
+	"STEAM_0:1:426473094": true,
+	"STEAM_0:1:420540284": true,
+	"STEAM_0:0:230868176": true,
+	"STEAM_0:0:229056813": true,
+	"STEAM_0:0:136196934": true,
+	"STEAM_0:1:235675215": true,
+	"STEAM_0:1:427222070": true
+}


### PR DESCRIPTION
메타테이블화 코드 삭제(DB 자체에서 Metatable 형태로 사용하는 편이 더 나음)
MsgC가 무조건 모두 빨간색으로 출력하는것 수정, 이제 [BABS]만 다른 색으로 출력
들여쓰기 수정
몇몇 명령어 서버콘솔 자체로도 사용 가능하도록 수정
**가족공유 무조건 킥할 때 다른 kick 사유 사용(혼동 우려)**
**DB의 자료구조를 JSON으로 변경, 단 호환을 위해 .html 파일도 유지**
Json의 장점:
* 더 보기 편함
* 더 강력
* 함수 하나만으로 Json <=> Lua metatable 변환 가능
* 테이블을 따로 메타테이블으로 변환할 필요 없음